### PR TITLE
Bugfix two images

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -21,7 +21,7 @@ android {
 dependencies {
     implementation fileTree(include: ['*.jar'], dir: 'libs')
     implementation 'com.android.support:appcompat-v7:27.1.1'
-    implementation 'com.android.support.constraint:constraint-layout:1.1.0'
+    implementation 'com.android.support.constraint:constraint-layout:1.1.2'
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'com.android.support.test:runner:1.0.2'
     androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'

--- a/app/src/main/java/com/smarteist/imageslider/MainActivity.java
+++ b/app/src/main/java/com/smarteist/imageslider/MainActivity.java
@@ -9,7 +9,6 @@ import com.smarteist.autoimageslider.SliderLayout;
 import com.smarteist.autoimageslider.SliderView;
 
 
-
 public class MainActivity extends AppCompatActivity {
 
     SliderLayout sliderLayout;
@@ -28,7 +27,7 @@ public class MainActivity extends AppCompatActivity {
 
     private void setSliderViews() {
 
-        for (int i = 0; i <= 3; i++) {
+        for (int i = 0; i <= 1; i++) {
 
             SliderView sliderView = new SliderView(this);
 

--- a/autoimageslider/build.gradle
+++ b/autoimageslider/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.2'
+        classpath 'com.android.tools.build:gradle:3.1.4'
     }
 }
 

--- a/autoimageslider/src/main/java/com/smarteist/autoimageslider/CircularSliderHandle.java
+++ b/autoimageslider/src/main/java/com/smarteist/autoimageslider/CircularSliderHandle.java
@@ -1,9 +1,6 @@
 package com.smarteist.autoimageslider;
 
 import android.support.v4.view.ViewPager;
-import android.util.Log;
-
-import static android.content.ContentValues.TAG;
 
 class CircularSliderHandle implements ViewPager.OnPageChangeListener {
     private ViewPager mViewPager;
@@ -53,15 +50,6 @@ class CircularSliderHandle implements ViewPager.OnPageChangeListener {
 
     @Override
     public void onPageScrollStateChanged(final int state) {
-        Log.d(TAG, "onPageScrollStateChanged: " + state + "   " + mCurrentPosition);
-//        int currentPage = mViewPager.getCurrentItem();
-//        if (currentPage == mViewPager.getAdapter().getCount()-1 || currentPage == 0){
-//            int previousState = mCurrentPosition;
-//            mCurrentPosition = state;
-//            if (previousState == 1 && mCurrentPosition == 0){
-//                mViewPager.setCurrentItem(currentPage == 0 ? mViewPager.getAdapter().getCount()-1 : 0);
-//            }
-//        }
         handleScrollState(state);
         mScrollState = state;
     }

--- a/autoimageslider/src/main/java/com/smarteist/autoimageslider/CircularSliderHandle.java
+++ b/autoimageslider/src/main/java/com/smarteist/autoimageslider/CircularSliderHandle.java
@@ -61,10 +61,6 @@ class CircularSliderHandle implements ViewPager.OnPageChangeListener {
 //            if (previousState == 1 && mCurrentPosition == 0){
 //                mViewPager.setCurrentItem(currentPage == 0 ? mViewPager.getAdapter().getCount()-1 : 0);
 //            }
-//            boolean leftSwipe = mPreviousPosition==
-//            if (state == ViewPager.SCROLL_STATE_SETTLING){
-//                mViewPager.setCurrentItem(currentPage == 0 ? mViewPager.getAdapter().getCount()-1 : 0);
-//            }
 //        }
         handleScrollState(state);
         mScrollState = state;

--- a/autoimageslider/src/main/java/com/smarteist/autoimageslider/CircularSliderHandle.java
+++ b/autoimageslider/src/main/java/com/smarteist/autoimageslider/CircularSliderHandle.java
@@ -1,12 +1,16 @@
 package com.smarteist.autoimageslider;
 
 import android.support.v4.view.ViewPager;
+import android.util.Log;
+
+import static android.content.ContentValues.TAG;
 
 class CircularSliderHandle implements ViewPager.OnPageChangeListener {
     private ViewPager mViewPager;
     private int mCurrentPosition;
 
     private CurrentPageListener currentPageListener;
+    private int mScrollState;
 
     CircularSliderHandle(final ViewPager viewPager) {
         mViewPager = viewPager;
@@ -22,16 +26,48 @@ class CircularSliderHandle implements ViewPager.OnPageChangeListener {
         currentPageListener.onCurrentPageChanged(mCurrentPosition);
     }
 
+    private void handleScrollState(final int state) {
+        if (state == ViewPager.SCROLL_STATE_IDLE) {
+            setNextItemIfNeeded();
+        }
+    }
+
+    private void setNextItemIfNeeded() {
+        if (!isScrollStateSettling()) {
+            handleSetNextItem();
+        }
+    }
+
+    private boolean isScrollStateSettling() {
+        return mScrollState == ViewPager.SCROLL_STATE_SETTLING;
+    }
+
+    private void handleSetNextItem() {
+        final int lastPosition = mViewPager.getAdapter().getCount() - 1;
+        if (mCurrentPosition == 0) {
+            mViewPager.setCurrentItem(lastPosition, false);
+        } else if (mCurrentPosition == lastPosition) {
+            mViewPager.setCurrentItem(0, false);
+        }
+    }
+
     @Override
     public void onPageScrollStateChanged(final int state) {
-        int currentPage = mViewPager.getCurrentItem();
-        if (currentPage == mViewPager.getAdapter().getCount()-1 || currentPage == 0){
-            int previousState = mCurrentPosition;
-            mCurrentPosition = state;
-            if (previousState == 1 && mCurrentPosition == 0){
-                mViewPager.setCurrentItem(currentPage == 0 ? mViewPager.getAdapter().getCount()-1 : 0);
-            }
-        }
+        Log.d(TAG, "onPageScrollStateChanged: " + state + "   " + mCurrentPosition);
+//        int currentPage = mViewPager.getCurrentItem();
+//        if (currentPage == mViewPager.getAdapter().getCount()-1 || currentPage == 0){
+//            int previousState = mCurrentPosition;
+//            mCurrentPosition = state;
+//            if (previousState == 1 && mCurrentPosition == 0){
+//                mViewPager.setCurrentItem(currentPage == 0 ? mViewPager.getAdapter().getCount()-1 : 0);
+//            }
+//            boolean leftSwipe = mPreviousPosition==
+//            if (state == ViewPager.SCROLL_STATE_SETTLING){
+//                mViewPager.setCurrentItem(currentPage == 0 ? mViewPager.getAdapter().getCount()-1 : 0);
+//            }
+//        }
+        handleScrollState(state);
+        mScrollState = state;
     }
 
     @Override

--- a/autoimageslider/src/main/java/com/smarteist/autoimageslider/IndicatorView/PageIndicatorView.java
+++ b/autoimageslider/src/main/java/com/smarteist/autoimageslider/IndicatorView/PageIndicatorView.java
@@ -19,6 +19,7 @@ import android.view.MotionEvent;
 import android.view.View;
 import android.view.ViewGroup;
 import android.view.ViewParent;
+
 import com.smarteist.autoimageslider.IndicatorView.animation.type.AnimationType;
 import com.smarteist.autoimageslider.IndicatorView.animation.type.BaseAnimation;
 import com.smarteist.autoimageslider.IndicatorView.animation.type.ColorAnimation;
@@ -134,10 +135,10 @@ public class PageIndicatorView extends View implements ViewPager.OnPageChangeLis
 
     @Override
     public void onPageScrollStateChanged(int state) {
-		if (state == ViewPager.SCROLL_STATE_IDLE) {
-			manager.indicator().setInteractiveAnimation(isInteractionEnabled);
-		}
-	}
+        if (state == ViewPager.SCROLL_STATE_IDLE) {
+            manager.indicator().setInteractiveAnimation(isInteractionEnabled);
+        }
+    }
 
     @Override
     public void onAdapterChanged(@NonNull ViewPager viewPager, @Nullable PagerAdapter oldAdapter, @Nullable PagerAdapter newAdapter) {
@@ -252,7 +253,6 @@ public class PageIndicatorView extends View implements ViewPager.OnPageChangeLis
         manager.indicator().setStroke((int) strokePx);
         invalidate();
     }
-
 
 
     public void setStrokeWidth(int strokeDp) {
@@ -574,7 +574,7 @@ public class PageIndicatorView extends View implements ViewPager.OnPageChangeLis
         }
     }
 
-	private void onPageScroll(int position, float positionOffset) {
+    private void onPageScroll(int position, float positionOffset) {
         Indicator indicator = manager.indicator();
         AnimationType animationType = indicator.getAnimationType();
         boolean interactiveAnimation = indicator.isInteractiveAnimation();
@@ -642,7 +642,7 @@ public class PageIndicatorView extends View implements ViewPager.OnPageChangeLis
         }
     }
 
-    private int adjustPosition(int position){
+    private int adjustPosition(int position) {
         Indicator indicator = manager.indicator();
         int count = indicator.getCount();
         int lastPosition = count - 1;

--- a/autoimageslider/src/main/java/com/smarteist/autoimageslider/SliderView.java
+++ b/autoimageslider/src/main/java/com/smarteist/autoimageslider/SliderView.java
@@ -149,10 +149,10 @@ public class SliderView {
         try {
             autoSliderImage.setScaleType(getScaleType());
             if (imageUrl != null) {
-                Glide.with(context).asDrawable().load(imageUrl).into(autoSliderImage);
+                Glide.with(context).load(imageUrl).into(autoSliderImage);
             }
             if (imageRes != 0){
-                Glide.with(context).asDrawable().load(imageRes).into(autoSliderImage);
+                Glide.with(context).load(imageRes).into(autoSliderImage);
             }
         } catch (Exception exception) {
             Log.d("Exception", exception.getMessage());

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.2'
+        classpath 'com.android.tools.build:gradle:3.1.4'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.7.3'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:1.5'
 


### PR DESCRIPTION
When two images are used, the second image scrolls faster. This bug is fixed and few libraries are updated to the latest.

**Overview**
- Two images bugs fix
- Few library updates
- Made Glide backward compatible