### PR TITLE
Override getItemPosition in SliderViewAdapter

### DIFF
--- a/autoimageslider/src/main/java/com/smarteist/autoimageslider/SliderViewAdapter.java
+++ b/autoimageslider/src/main/java/com/smarteist/autoimageslider/SliderViewAdapter.java
@@ -51,6 +51,11 @@ public abstract class SliderViewAdapter<VH extends SliderViewAdapter.ViewHolder>
         return ((VH) object).itemView == view;
     }
 
+    @Override
+    public final int getItemPosition(@NonNull Object object) {
+        return POSITION_NONE;
+    }
+
     /**
      * Create a new view holder
      * @param parent wrapper view


### PR DESCRIPTION
If getItemPosition is not overloaded, then notifyDatasetChanged does nothing.

cc @smarteist 