### PR TITLE
Fixed bug that led to wrong position calculation in InfinitePagerAdapter.

### DIFF
--- a/autoimageslider/src/main/java/com/smarteist/autoimageslider/InfiniteAdapter/InfinitePagerAdapter.java
+++ b/autoimageslider/src/main/java/com/smarteist/autoimageslider/InfiniteAdapter/InfinitePagerAdapter.java
@@ -57,10 +57,15 @@ public class InfinitePagerAdapter extends PagerAdapter {
      * @return virtual mid point
      */
     public int getMiddlePosition(int item) {
-        int adapterCount = getRealCount() - 1;
-        adapterCount = adapterCount == 0 ? 1 : adapterCount;
+        int realCount = getRealCount();
+        int adapterCount = realCount - 1 == 0 ? 1 : realCount - 1;
         int midpoint = adapterCount * (InfinitePagerAdapter.INFINITE_SCROLL_LIMIT / 2);
-        return item + midpoint;
+
+        if (realCount != 0 && midpoint % realCount != 0) {
+            return midpoint + (realCount - midpoint % realCount) + item;
+        } else {
+            return midpoint + item;
+        }
     }
 
     @NonNull


### PR DESCRIPTION
resolves #168 
I fixed a strange algorithm that calculates the middle position. Now it will calculate it correctly. 
I hope you will check out my fix. Fill free to ask to correct smth.

Problem was in `getMiddlePosition(int item)` function in `InfinitePagerAdapter`. With some `item` values `midpoint + item` mod itemCount was not equal to 0. Because of that sometimes the first position was shifted.