### PR TITLE
fix: second-page always flip after first looping

### DIFF
--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -3,4 +3,7 @@
   <component name="Kotlin2JsCompilerArguments">
     <option name="sourceMapEmbedSources" />
   </component>
+  <component name="KotlinJpsPluginSettings">
+    <option name="version" value="1.8.22" />
+  </component>
 </project>

--- a/autoimageslider/src/main/java/com/smarteist/autoimageslider/SliderView.java
+++ b/autoimageslider/src/main/java/com/smarteist/autoimageslider/SliderView.java
@@ -710,6 +710,7 @@ public class SliderView extends FrameLayout
         if (mIsInfiniteAdapter) {
             mInfinitePagerAdapter.notifyDataSetChanged();
             mSliderPager.setCurrentItem(0, false);
+            mPagerIndicator.setViewPager(mSliderPager);
         }
     }
 

--- a/autoimageslider/src/main/java/com/smarteist/autoimageslider/SliderView.java
+++ b/autoimageslider/src/main/java/com/smarteist/autoimageslider/SliderView.java
@@ -652,8 +652,6 @@ public class SliderView extends FrameLayout
         }
     }
 
-    int currentContinuousPosition = 0;
-
     public void slideToNextPosition() {
 
         int currentPosition = mSliderPager.getCurrentItem();
@@ -668,17 +666,15 @@ public class SliderView extends FrameLayout
                 } else {
                     mSliderPager.setCurrentItem(currentPosition - 1, true);
                 }
-                mPreviousPosition = currentPosition;
             }
             if (mAutoCycleDirection == AUTO_CYCLE_DIRECTION_LEFT) {
-                mSliderPager.setCurrentItem(currentContinuousPosition--, true);
-                mPreviousPosition = currentContinuousPosition;
+                mSliderPager.setCurrentItem(currentPosition == 0 ? adapterItemsCount - 1 : currentPosition - 1, currentPosition != 0);
             }
             if (mAutoCycleDirection == AUTO_CYCLE_DIRECTION_RIGHT) {
-                mSliderPager.setCurrentItem(currentContinuousPosition++, true);
-                mPreviousPosition = currentContinuousPosition;
+                mSliderPager.setCurrentItem(currentPosition == adapterItemsCount - 1 ? 0 : currentPosition + 1, currentPosition != adapterItemsCount - 1);
             }
         }
+        mPreviousPosition = currentPosition;
     }
 
 

--- a/autoimageslider/src/main/java/com/smarteist/autoimageslider/SliderView.java
+++ b/autoimageslider/src/main/java/com/smarteist/autoimageslider/SliderView.java
@@ -652,6 +652,8 @@ public class SliderView extends FrameLayout
         }
     }
 
+    int currentContinuousPosition = 0;
+
     public void slideToNextPosition() {
 
         int currentPosition = mSliderPager.getCurrentItem();
@@ -666,15 +668,17 @@ public class SliderView extends FrameLayout
                 } else {
                     mSliderPager.setCurrentItem(currentPosition - 1, true);
                 }
+                mPreviousPosition = currentPosition;
             }
             if (mAutoCycleDirection == AUTO_CYCLE_DIRECTION_LEFT) {
-                mSliderPager.setCurrentItem(currentPosition - 1, true);
+                mSliderPager.setCurrentItem(currentContinuousPosition--, true);
+                mPreviousPosition = currentContinuousPosition;
             }
             if (mAutoCycleDirection == AUTO_CYCLE_DIRECTION_RIGHT) {
-                mSliderPager.setCurrentItem(currentPosition + 1, true);
+                mSliderPager.setCurrentItem(currentContinuousPosition++, true);
+                mPreviousPosition = currentContinuousPosition;
             }
         }
-        mPreviousPosition = currentPosition;
     }
 
 


### PR DESCRIPTION
- Change the flip issue position to last page.
- But still flip animation obviously and not good at UX,
- Disable smoothScroll at LastPage->FirstPage.